### PR TITLE
Supply of instructors for Guitar Ensemble CCA Training Programme in PHPPS from Jan 2026 to Dec 2026, with option to extend from Jan 2027 to Dec 2027

### DIFF
--- a/_our-partners/Invitation To Quote (ITQ) & Request For Quotation (RFQ).md
+++ b/_our-partners/Invitation To Quote (ITQ) & Request For Quotation (RFQ).md
@@ -33,6 +33,14 @@ variant: markdown
 <tr>
 		</tr>	<tr>
 	</tr>	<tr>
+		</tr>	<tr>
+			</tr>	<tr>
+	</tr>	<tr><td class="tg-q1lf"><span style="color:#282828;background-color:transparent">MOESCHETQ25002745 </span></td>
+    <td class="tg-q1lf"><span style="color:#282828;background-color:transparent">Supply of instructors for Guitar Ensemble CCA Training Programme in PHPPS from Jan 2026 to Dec 2026, with option to extend from Jan 2027 to Dec 2027 </span></td>
+    <td class="tg-q1lf"><span style="color:#282828;background-color:transparent">06 June 2025 </span></td>
+    <td class="tg-q1lf"><span style="color:#282828;background-color:transparent">20 June 2025 1:00PM </span></td>
+  </tr><tr>
+	</tr>	<tr>
 	</tr>	<tr>
 			</tr>	<tr>
 	</tr>	<tr><td class="tg-q1lf"><span style="color:#282828;background-color:transparent">MOESCHETQ25002071 </span></td>


### PR DESCRIPTION
Document no.	:	MOESCHETQ25002745
Reference no.	:	2026GuitarLine1
Agency	:	Ministry of Education - Schools
Title	:	Supply of instructors for Guitar Ensemble CCA Training Programme in PHPPS from Jan 2026 to Dec 2026, with option to extend from Jan 2027 to Dec 2027
Publish date	:	06 Jun 2025
Close date	:	20 Jun 2025 01:00 PM
