### PR TITLE
Visit by Ex-PHPPS Students on 4 Sept (Thursday)

### DIFF
--- a/index.md
+++ b/index.md
@@ -36,7 +36,7 @@ sections:
         - title: Visit by Ex-PHPPS Students on 4 Sept (Thursday)
           date: 25 August 2025
           announcement: "The school will be open from 11.00 to 12.00 noon for students who
-            have made prior appointments with their teachers.   We seek your
+            have made prior appointments with their teachers. We seek your
             cooperation in ensuring that all students make an appointment in
             advance before visiting.   Locations: Canteen, Foyer Level 1, or
             outside the staff room on Level 2."


### PR DESCRIPTION
Visit by Ex-PHPPS Students on 4 Sept (Thursday)
The school will be open from 11.00 a.m. to 12.00 noon for ex-PHPPS students who have made prior appointments with their teachers. To avoid disappointment, we seek your cooperation in ensuring that all returning students make an appointment in advance before visiting. Kindly remain at the canteen, Foyer Level 1 or Level 2 outside staff room.