### PR TITLE
Business opportunity has been published (MOESCHETQ25003854)_Tchoukball CCA 2026, with option to extend from Jan 2027 to Dec 2027

### DIFF
--- a/_our-partners/Invitation To Quote (ITQ) & Request For Quotation (RFQ).md
+++ b/_our-partners/Invitation To Quote (ITQ) & Request For Quotation (RFQ).md
@@ -36,6 +36,12 @@ variant: markdown
 		</tr>	<tr></tr>	<tr>
 	</tr>	<tr></tr>	<tr>
 			</tr>	<tr>
+	</tr>	<tr><td class="tg-q1lf"><span style="color:#282828;background-color:transparent">MOESCHETQ25003854</span></td>
+    <td class="tg-q1lf"><span style="color:#282828;background-color:transparent">Supply of instructors for Tchoukball CCA Training Programme in PHPPS from Jan 2026 to Dec 2026, with option to extend from Jan 2027 to Dec 2027 </span></td>
+    <td class="tg-q1lf"><span style="color:#282828;background-color:transparent">26 Aug 2025 </span></td>
+    <td class="tg-q1lf"><span style="color:#282828;background-color:transparent">03 Sep 2025 1:00PM </span></td>
+			</tr>	<tr></tr>	<tr>
+			</tr>	<tr>
 	</tr>	<tr><td class="tg-q1lf"><span style="color:#282828;background-color:transparent">MOESCHETQ25003512</span></td>
     <td class="tg-q1lf"><span style="color:#282828;background-color:transparent">Supply of Instructor for Guzheng Ensemble CCA Training Programme in PHPPS from Jan to Dec 2026, with option to extend from Jan to Dec 2027 </span></td>
     <td class="tg-q1lf"><span style="color:#282828;background-color:transparent">06 Aug 2025 </span></td>


### PR DESCRIPTION
We have put up a fresh/new ITQ again today for Tchoukball 2026. 
Do remember to invite potential suppliers to submit their bid before the ITQ closing date to avoid getting no bid or single bid.

